### PR TITLE
Handle missing temp files during cleanup

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -53,7 +53,10 @@ class Process:
             self.kill()
         for f in self._files.values():
             f.close()
-            os.unlink(f.name)
+            try:
+                os.unlink(f.name)
+            except FileNotFoundError:
+                pass
 
     @property
     def pid(self):


### PR DESCRIPTION
## Summary
- prevent `Process.__del__` from crashing if temporary files already removed

## Testing
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_68baee57537883318f5ca9b67554d597