### PR TITLE
Fix compare_files missing file handling

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -114,9 +114,11 @@ def compare_project_file(filename):
 
 
 def compare_files(file1_path, file2_path):
-    # if either of the files does not exist, return False
+    # return False if either path is missing or the file does not exist
+    if not file1_path or not file2_path:
+        return False
     if not os.path.exists(file1_path) or not os.path.exists(file2_path):
-        return True
+        return False
 
     try:
         with open(file1_path, "rb") as file1:
@@ -131,7 +133,7 @@ def compare_files(file1_path, file2_path):
 
     except FileNotFoundError:
         logging.error("Error during file comparison!")
-        return True
+        return False
 
 
 def create_temporary_project_files():

--- a/test/compare_files_test.py
+++ b/test/compare_files_test.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import types
+import tempfile
+import unittest
+from unittest import mock
+
+import qt_stubs  # noqa: F401
+
+# Provide a minimal vtk stub before importing settings
+vtk_stub = types.ModuleType("vtk")
+
+
+class DummyNamedColors:
+    def GetColor3d(self, key):
+        return (0.0, 0.0, 0.0)
+
+
+vtk_stub.vtkNamedColors = DummyNamedColors
+sys.modules["vtk"] = vtk_stub
+
+from src.settings import compare_files
+
+
+class CompareFilesTest(unittest.TestCase):
+    def test_missing_first_file_returns_false(self):
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(b"data")
+            existing_path = temp_file.name
+        missing_path = existing_path + "_missing"
+        self.assertFalse(compare_files(missing_path, existing_path))
+        os.remove(existing_path)
+
+    def test_missing_second_file_returns_false(self):
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(b"data")
+            existing_path = temp_file.name
+        missing_path = existing_path + "_missing"
+        self.assertFalse(compare_files(existing_path, missing_path))
+        os.remove(existing_path)
+
+    def test_both_files_missing_returns_false(self):
+        import uuid
+
+        missing1 = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
+        missing2 = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
+        self.assertFalse(compare_files(missing1, missing2))
+
+    def test_file_not_found_during_read_returns_false(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f1:
+            path1 = f1.name
+        with tempfile.NamedTemporaryFile(delete=False) as f2:
+            path2 = f2.name
+        with mock.patch("builtins.open", side_effect=FileNotFoundError()):
+            self.assertFalse(compare_files(path1, path2))
+        os.remove(path1)
+        os.remove(path2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure compare_files returns False when either path is missing or nonexistent
- return False when a FileNotFoundError occurs
- add tests covering missing/removed project files

## Testing
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c43ade52ac8331ab64e4cfb67a11b4