### PR TITLE
feat(supports): add min island area setting

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -168,6 +168,7 @@ supports:
   bottoms_depth: 0
   lids_depth: 0
   create_walls: true
+  min_island_area: 0.0
 uninterrupted_print:
   enabled: false
   cut_distance: 0.0

--- a/src/locales.py
+++ b/src/locales.py
@@ -157,6 +157,7 @@ class Locale:
     CannotDropHere = "Figure cannot be dropped here"
 
     ShouldCreateWalls = "Create wall in support"
+    SupportMinIslandArea = "Support min island area, mm²:"
 
     AutoFanEnabled = "Enable auto fan speed adjustment"
     AutoFanArea = "Auto fan max area, mm²:"
@@ -334,6 +335,7 @@ dicts = {
         WarningPathNotClosed="При разрезании модели были обнаружены незамкнутые участки! Проверьте корректность расположения фигур",
         CannotDropHere="Фигура не может быть перенесена сюда",
         ShouldCreateWalls="Создавать стенки в поддержках",
+        SupportMinIslandArea="Минимальная площадь острова поддержек, мм²:",
         AutoFanEnabled="Включить автоматическое управление обдувом",
         AutoFanArea="Максимальная площадь для автоматического обдува, мм²:",
         AutoFanSpeed="Скорость автоматического обдува:",

--- a/src/settings_widget.py
+++ b/src/settings_widget.py
@@ -120,6 +120,7 @@ class SettingsWidget(QToolBox):
         "support_number_of_bottom_layers",
         "support_number_of_lid_layers",
         "support_create_walls",
+        "support_min_island_area",
         "critical_angle",
         "filter_tolerance",
         "smooth_coefficient",
@@ -177,6 +178,7 @@ class SettingsWidget(QToolBox):
             "support_number_of_bottom_layers",
             "support_number_of_lid_layers",
             "support_create_walls",
+            "support_min_island_area",
         ],
     }
 
@@ -1803,6 +1805,36 @@ class SettingsWidget(QToolBox):
             self.__elements[name] = {
                 "label": create_walls_label,
                 "checkbox": create_walls_box,
+            }
+        elif name == "support_min_island_area":
+            self.ensure_sett("supports.min_island_area")
+
+            support_min_island_area_label = QLabel(self.locale.SupportMinIslandArea)
+            support_min_island_area_value = QDoubleSpinBox()
+            support_min_island_area_value.setMinimum(0.0)
+            support_min_island_area_value.setMaximum(9999.0)
+            support_min_island_area_value.validator = FloatValidator()
+            try:
+                support_min_island_area_value.setValue(
+                    self.sett().supports.min_island_area
+                )
+            except:
+                support_min_island_area_value.setValue(0.0)
+            panel.addWidget(support_min_island_area_label, panel_next_row(), 1)
+            panel.addWidget(
+                support_min_island_area_value, panel_cur_row(), 2, 1, self.col2_cells
+            )
+
+            def on_change():
+                self.sett().supports.min_island_area = (
+                    support_min_island_area_value.value()
+                )
+
+            support_min_island_area_value.valueChanged.connect(on_change)
+
+            self.__elements[name] = {
+                "label": support_min_island_area_label,
+                "spinbox": support_min_island_area_value,
             }
         elif name == "auto_fan_enabled":
             self.ensure_sett("slicing.auto_fan.enabled")


### PR DESCRIPTION
## Summary
- Add `supports.min_island_area` to default settings, widget, and EN/RU locales.

Pairs with epit3d/goosli_v2#215 (backend threshold).

## Test plan
- [ ] Supports panel shows the new spinbox and persists to settings.yaml.